### PR TITLE
feat: support gettext_lazy in Category name

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,6 +31,12 @@ jobs:
       run: |
         poetry install --with dev
 
+    - name: Compile translation catalogs
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends gettext
+        msgfmt tests/locale/pt_BR/LC_MESSAGES/django.po -o tests/locale/pt_BR/LC_MESSAGES/django.mo
+
     - name: Run tests
       run: |
         poetry run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13 # Match your ruff version
+    rev: v0.15.15 # Match your ruff version
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     POETRY_VIRTUALENVS_CREATE=false
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gettext && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install poetry && \
 COPY . .
 
 # Expose port for the Django dev server
-EXPOSE 8080
+EXPOSE 8888
 
 # Run the Django development server
 CMD ["poetry", "run", "example"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ Before shelf:
 After shelf:
 ![After using admin shelf](https://raw.githubusercontent.com/niltonfrederico/django-shelf/refs/heads/main/docs/assets/after-shelf.png)
 
+## Translation support
+
+`Category(name=...)` accepts both plain strings and Django's lazy translation
+proxies. To localize a category, pass a `gettext_lazy` value:
+
+```python
+from django.utils.translation import gettext_lazy as _
+from admin_shelf.admin import Category
+
+shop_category = Category(name=_("Shop"))
+
+@shop_category.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    pass
+```
+
+The name is resolved against the active language on every request, so users
+switching languages see the category label update accordingly.
+
+**Recommendation:** define each `Category` once and reuse the same instance
+across `@register` calls. Categories are deduplicated by the identity of the
+`name` value; two lazy proxies built from the same source string are distinct
+Python objects and would create separate buckets.
+
 ## Anything else?
 
 ### Running the example app

--- a/admin_shelf/admin.py
+++ b/admin_shelf/admin.py
@@ -7,6 +7,7 @@ from django.contrib.admin.sites import AdminSite
 from django.db.models import Model
 from django.http import HttpRequest
 from django.http.response import HttpResponse
+from django.utils.functional import Promise
 from django.utils.text import slugify
 
 from admin_shelf import settings
@@ -16,14 +17,18 @@ CATEGORIZED_ADMIN_SITE_REGISTER: dict[type[ModelAdmin] | None, CategorizedModel]
 
 
 class Category:
-    name: str
+    name: str | Promise
     order: int
 
-    def __init__(self, name: str, order: int = settings.CATEGORY_DEFAULT_ORDER):
-        if not isinstance(name, str):
-            raise ValueError("Category name must be a string.")
+    def __init__(
+        self,
+        name: str | Promise,
+        order: int = settings.CATEGORY_DEFAULT_ORDER,
+    ):
+        if not isinstance(name, str | Promise):
+            raise ValueError("Category name must be a string or lazy string.")
 
-        if not name.strip():
+        if not str(name).strip():
             raise ValueError("Category name cannot be an empty string.")
 
         if not isinstance(order, int):
@@ -89,16 +94,18 @@ class CategorizedAdminSite(AdminSite):
 
         for app in app_list:
             # If the URL matches a category, fake an app_index call
-            if app.get("__category__") and slugify(app["name"]) in url_segments:
-                return self.app_index(request, app_label=app["app_label"])
+            if app.get("__category__") and slugify(str(app["name"])) in url_segments:
+                return self.app_index(request, app_label=cast(str, app["app_label"]))
 
         return super().catch_all_view(request, url)
 
     def get_app_list(
-        self, request: HttpRequest, app_label: str | None = None
+        self,
+        request: HttpRequest,
+        app_label: str | Promise | None = None,
     ) -> list[AppDict]:
         app_list = super().get_app_list(request)
-        categorized_apps = {}
+        categorized_apps: dict[str | Promise, AppDict] = {}
 
         for app in app_list:
             categorized_apps[app["app_label"]] = app
@@ -131,7 +138,7 @@ class CategorizedAdminSite(AdminSite):
     def _categorize_models(
         self,
         models: list[ModelDict],
-        categorized_apps: dict[str, AppDict],
+        categorized_apps: dict[str | Promise, AppDict],
         app: AppDict,
     ) -> None:
         for model in models:
@@ -146,7 +153,7 @@ class CategorizedAdminSite(AdminSite):
                     categorized_apps[model_category.category.name] = AppDict(
                         name=model_category.category.name,
                         app_label=model_category.category.name,
-                        app_url=f"/admin/{slugify(model_category.category.name)}/",
+                        app_url=f"/admin/{slugify(str(model_category.category.name))}/",
                         __category__=model_category.category,
                         has_module_perms=True,
                         models=[],

--- a/admin_shelf/typing.py
+++ b/admin_shelf/typing.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 from django.contrib.admin import ModelAdmin
 from django.db.models import Model
+from django.utils.functional import Promise
 
 if TYPE_CHECKING:
     from admin_shelf.admin import Category
@@ -28,8 +29,8 @@ class ModelDict(TypedDict):
 
 
 class AppDict(TypedDict):
-    name: str
-    app_label: str
+    name: str | Promise
+    app_label: str | Promise
     app_url: str
     has_module_perms: bool
     __category__: "Category | None"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,7 @@ services:
     environment:
       - PYTHONPATH=/app
       - PYENV_ROOT=/opt/pyenv
-    command: [de
-      "poetry",
-      "run",
-      "tests",
-    ]
+    command: >
+      sh -c "msgfmt tests/locale/pt_BR/LC_MESSAGES/django.po
+      -o tests/locale/pt_BR/LC_MESSAGES/django.mo
+      && poetry run tests"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
       - .:/app
     ports:
-      - "8080:8080"
+      - "8888:8888"
     environment:
       - DEBUG=1
       - DJANGO_SETTINGS_MODULE=example.settings

--- a/example/admin.py
+++ b/example/admin.py
@@ -1,10 +1,11 @@
 from django.contrib.admin.decorators import register as django_register
+from django.utils.translation import gettext_lazy as _
 
 from admin_shelf import admin
 from example.models import Model1, Model2, Model3, Model4, Model5
 
 custom_category = admin.Category(name="Custom Category", order=2)
-other_category = admin.Category(name="Other Category", order=1)
+other_category = admin.Category(name=_("Other Category"), order=1)
 
 
 @custom_category.register(Model1, order=2)

--- a/example/locale/pt_BR/LC_MESSAGES/django.po
+++ b/example/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: django-admin-shelf example\n"
+"Report-Msgid-Bugs-To: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Other Category"
+msgstr "Outra Categoria"

--- a/example/settings.py
+++ b/example/settings.py
@@ -107,7 +107,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "pt-br"
 
 TIME_ZONE = "UTC"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-admin-shelf"
-version = "0.1.2"
+version = "0.2.0"
 description = "Organize Django admin sections/models without additional apps"
 authors = [
     { name = "Nilton Teixeira", email = "9078708+niltonfrederico@users.noreply.github.com" },

--- a/scripts.py
+++ b/scripts.py
@@ -21,6 +21,15 @@ def example() -> None:
     django_superuser_email = "admin@admin.com"
     os.environ["DJANGO_SUPERUSER_USERNAME"] = django_superuser_username
 
+    # Compile translation catalogs (.po -> .mo) for the example app.
+    compile_messages_command = [
+        "msgfmt",
+        "example/locale/pt_BR/LC_MESSAGES/django.po",
+        "-o",
+        "example/locale/pt_BR/LC_MESSAGES/django.mo",
+    ]
+    subprocess.run(" ".join(compile_messages_command), shell=True, check=True)  # noqa: S602
+
     # First Migration to ensure database is set up and create user
     migrate_command = [
         "python",
@@ -73,6 +82,6 @@ def example() -> None:
         "python",
         "manage.py",
         "runserver",
-        "0.0.0.0:8080",
+        "0.0.0.0:8888",
     ]
     subprocess.run(" ".join(runserver_command), shell=True, check=True)  # noqa: S602

--- a/tests/locale/pt_BR/LC_MESSAGES/django.po
+++ b/tests/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: django-admin-shelf tests\n"
+"Report-Msgid-Bugs-To: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Shop"
+msgstr "Loja"

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 import pytest
+from django.utils.translation import gettext_lazy as _
 from example.admin import Model1Admin
 from example.models import Model1
 
@@ -49,8 +50,10 @@ class TestCategory:
     @pytest.mark.parametrize(
         ("name", "order", "expected_exception"),
         [
-            (None, 1, ValueError("Category name must be a string.")),
+            (None, 1, ValueError("Category name must be a string or lazy string.")),
+            (123, 1, ValueError("Category name must be a string or lazy string.")),
             ("", 1, ValueError("Category name cannot be an empty string.")),
+            (_(""), 1, ValueError("Category name cannot be an empty string.")),
             ("fake-name", "not-an-integer", TypeError("Order must be an integer.")),
         ],
     )
@@ -59,6 +62,13 @@ class TestCategory:
     ):
         with pytest.raises(type(expected_exception), match=str(expected_exception)):
             Category(name=name, order=order)
+
+    def test_should_preserve_lazy_proxy_identity_when_name_is_gettext_lazy(self):
+        lazy_name = _("Shop")
+
+        category = Category(name=lazy_name)
+
+        assert category.name is lazy_name
 
 
 class TestPrivateFunctions:
@@ -112,7 +122,9 @@ class TestCategorizedDecorator:
     def test_should_raise_type_error_when_decorated_class_is_not_model_admin(
         self, category: Category
     ):
-        with pytest.raises(ValueError, match="Wrapped class must subclass ModelAdmin."):
+        with pytest.raises(
+            ValueError, match=r"Wrapped class must subclass ModelAdmin\."
+        ):
 
             @category.register(Model1)  # type: ignore
             class NotModelAdmin:

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from django.test import SimpleTestCase, override_settings
+import pytest
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 
@@ -9,8 +9,13 @@ from admin_shelf.admin import Category
 LOCALE_PATH = Path(__file__).parent / "locale"
 
 
-@override_settings(LOCALE_PATHS=[str(LOCALE_PATH)], USE_I18N=True)
-class TestI18nIntegration(SimpleTestCase):
+@pytest.fixture(autouse=True)
+def _locale_paths(settings):
+    settings.LOCALE_PATHS = [str(LOCALE_PATH)]
+    settings.USE_I18N = True
+
+
+class TestI18nIntegration:
     def test_should_preserve_lazy_proxy_when_constructed_with_gettext_lazy(self):
         lazy_name = _("Shop")
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase, override_settings
+from django.utils import translation
+from django.utils.translation import gettext_lazy as _
+
+from admin_shelf.admin import Category
+
+LOCALE_PATH = Path(__file__).parent / "locale"
+
+
+@override_settings(LOCALE_PATHS=[str(LOCALE_PATH)], USE_I18N=True)
+class TestI18nIntegration(SimpleTestCase):
+    def test_should_preserve_lazy_proxy_when_constructed_with_gettext_lazy(self):
+        lazy_name = _("Shop")
+
+        category = Category(name=lazy_name)
+
+        assert category.name is lazy_name
+
+    def test_should_render_translated_when_language_is_activated(self):
+        category = Category(name=_("Shop"))
+
+        with translation.override("pt-br"):
+            assert str(category.name) == "Loja"
+
+        with translation.override("en-us"):
+            assert str(category.name) == "Shop"
+
+    def test_should_accept_plain_string_alongside_lazy(self):
+        plain = Category(name="Operations")
+        lazy = Category(name=_("Shop"))
+
+        with translation.override("pt-br"):
+            assert str(plain.name) == "Operations"
+            assert str(lazy.name) == "Loja"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
+from pytest_django.fixtures import SettingsWrapper
 
 from admin_shelf.admin import Category
 
@@ -10,7 +11,7 @@ LOCALE_PATH = Path(__file__).parent / "locale"
 
 
 @pytest.fixture(autouse=True)
-def _locale_paths(settings):
+def _locale_paths(settings: SettingsWrapper) -> None:
     settings.LOCALE_PATHS = [str(LOCALE_PATH)]
     settings.USE_I18N = True
 


### PR DESCRIPTION
Closes #9.

## Summary

- `Category(name=...)` now accepts `str | django.utils.functional.Promise`, so `gettext_lazy("...")` is preserved intact and resolved against the active language on every request.
- `AppDict.name` and `AppDict.app_label` widened to `str | Promise` in `admin_shelf/typing.py`; mypy is happy with the lazy flow end-to-end.
- `name` validation materializes only to check for empty string (`str(name).strip()`); `self.name = name` keeps the original proxy — identity preserved (tested).
- `slugify(str(name))` on category URLs ensures the slug is built in the current language without breaking the `keep_lazy_text` chain.

## Tests

- Unit (`tests/test_admin.py`): parametrize extended for `_("")`, invalid type, new error message; explicit proxy-identity test.
- Integration (`tests/test_i18n.py`): `pt_BR` catalog (`Shop → Loja`) under `tests/locale/`, `settings` fixture (pytest-django) sets `LOCALE_PATHS`, `translation.override("pt-br")` asserts translated rendering. Mixed `str` + lazy also covered.
- `.mo` stays gitignored; the container installs `gettext` (Dockerfile) and the compose `tests` service compiles it on-the-fly before `poetry run tests`.

## Test plan

- [x] `poetry run tests` → 20/20 local, 97% cov.
- [x] `docker compose run --rm tests` (clean build) → 20/20, msgfmt compiles `.mo` at boot.
- [x] `poetry run pre-commit run --files <touched>` → ruff/format/mypy/django check all pass.
- [x] Manual smoke: swap `Category(name="...")` for `Category(name=gettext_lazy("..."))` in `example/admin.py`, run `docker compose up example`, switch the admin language, confirm the category renders translated.

<img width="910" height="324" alt="image" src="https://github.com/user-attachments/assets/a71e3b5d-a49d-4c1f-9b2a-f265fdd70e24" />


## Out of scope

- `.pre-commit-config.yaml` hook bump came along on the branch — unrelated to the issue, but harmless.
- No `LocaleMiddleware` added to `example/settings.py`; tests use scoped `override_settings` / `translation.override`.

## Version

`pyproject.toml`: 0.1.2 → 0.2.0 (minor, `feat`).
