### PR TITLE
docs: expand README per #12, add mdformat hook

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,3 @@
+wrap = "keep"
+number = false
+end_of_line = "lf"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,13 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+
   - repo: local
     hooks:
       - id: mypy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,19 @@ There will be only five rules for contributing to this project:
 
 1. Don't be an asshole. (No trolling, harassment, discrimination, homophobia, transphobia, racism, sexism, ableism, ageism, or any other form of hate speech.)
 
-   a. Yes, there will be **no tolerance**, no matter how good your code is.
+   1. Yes, there will be **no tolerance**, no matter how good your code is.
 
-   b. If you don't know why this is important, please read the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+   1. If you don't know why this is important, please read the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 
-   c. Also read about the Tolerance Paradox:
+   1. Also read about the Tolerance Paradox:
 
-   - [English](https://en.wikipedia.org/wiki/Tolerance_paradox)
-   - [Português](https://pt.wikipedia.org/wiki/Paradoxo_da_toler%C3%A2ncia)
-   - [Español](https://es.wikipedia.org/wiki/Paradoja_de_la_tolerancia)
-   - [Français](https://fr.wikipedia.org/wiki/Paradoxe_de_la_tol%C3%A9rance)
-   - [Italiano](https://it.wikipedia.org/wiki/Paradosso_della_tolleranza)
-   - [Deutsch](https://de.wikipedia.org/wiki/Toleranzparadoxon)
-   - [Русский](https://ru.wikipedia.org/wiki/%D0%9F%D0%B0%D1%80%D0%B0%D0%B4%D0%BE%D0%BA%D1%81_%D1%82%D0%B5%D1%80%D0%BF%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D0%B8)
+      - [English](https://en.wikipedia.org/wiki/Tolerance_paradox)
+      - [Português](https://pt.wikipedia.org/wiki/Paradoxo_da_toler%C3%A2ncia)
+      - [Español](https://es.wikipedia.org/wiki/Paradoja_de_la_tolerancia)
+      - [Français](https://fr.wikipedia.org/wiki/Paradoxe_de_la_tol%C3%A9rance)
+      - [Italiano](https://it.wikipedia.org/wiki/Paradosso_della_tolleranza)
+      - [Deutsch](https://de.wikipedia.org/wiki/Toleranzparadoxon)
+      - [Русский](https://ru.wikipedia.org/wiki/%D0%9F%D0%B0%D1%80%D0%B0%D0%B4%D0%BE%D0%BA%D1%81_%D1%82%D0%B5%D1%80%D0%BF%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D0%B8)
 
 1. Follow the project's coding style.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There will be only five rules for contributing to this project:
 
 And **one** wish:
 
-I really don't like to work with django templates, that's why I created it this way. If you want to contribute with a new feature that requires a template, please consider using a different approach. This minimizes the learning curve for whoever uses it and makes it easier to maintain the project in the long run. If you have a great idea that requires a template, let's discuss it first to find the best way to implement it without relying on Django's templating system.
+I really don't like to work with Django templates, that's why I created it this way. If you want to contribute with a new feature that requires a template, please consider using a different approach. This minimizes the learning curve for whoever uses it and makes it easier to maintain the project in the long run. If you have a great idea that requires a template, let's discuss it first to find the best way to implement it without relying on Django's templating system.
 
 Thanks y'all!
 Nilton Teixeira, aka @kuresto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,30 @@
 There will be only five rules for contributing to this project:
 
 1. Don't be an asshole. (No trolling, harassment, discrimination, homophobia, transphobia, racism, sexism, ableism, ageism, or any other form of hate speech.)
-   1. Yes, there will be **no tolerance**, no matter how good your code is.
-   2. If you don't know why this is important, please read the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
-   3. Also read about the Tolerance Paradox:
-      - [English](https://en.wikipedia.org/wiki/Tolerance_paradox)
-      - [Português](https://pt.wikipedia.org/wiki/Paradoxo_da_toler%C3%A2ncia)
-      - [Español](https://es.wikipedia.org/wiki/Paradoja_de_la_tolerancia)
-      - [Français](https://fr.wikipedia.org/wiki/Paradoxe_de_la_tol%C3%A9rance)
-      - [Italiano](https://it.wikipedia.org/wiki/Paradosso_della_tolleranza)
-      - [Deutsch](https://de.wikipedia.org/wiki/Toleranzparadoxon)
-      - [Русский](https://ru.wikipedia.org/wiki/Парадокс_терпимости)
-2. Follow the project's coding style.
-3. Write clear and concise commit messages, preferably using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+   a. Yes, there will be **no tolerance**, no matter how good your code is.
+
+   b. If you don't know why this is important, please read the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+   c. Also read about the Tolerance Paradox:
+
+   - [English](https://en.wikipedia.org/wiki/Tolerance_paradox)
+   - [Português](https://pt.wikipedia.org/wiki/Paradoxo_da_toler%C3%A2ncia)
+   - [Español](https://es.wikipedia.org/wiki/Paradoja_de_la_tolerancia)
+   - [Français](https://fr.wikipedia.org/wiki/Paradoxe_de_la_tol%C3%A9rance)
+   - [Italiano](https://it.wikipedia.org/wiki/Paradosso_della_tolleranza)
+   - [Deutsch](https://de.wikipedia.org/wiki/Toleranzparadoxon)
+   - [Русский](https://ru.wikipedia.org/wiki/%D0%9F%D0%B0%D1%80%D0%B0%D0%B4%D0%BE%D0%BA%D1%81_%D1%82%D0%B5%D1%80%D0%BF%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D0%B8)
+
+1. Follow the project's coding style.
+
+1. Write clear and concise commit messages, preferably using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
    - Example: `feat: add new feature`, `fix: correct a bug`, `docs: update documentation`, `style: improve code formatting`, etc.
-4. I will only review and accept pull requests with tests that cover the changes made.
-5. Always create an issue before starting to work on a new feature or bug fix, so we can discuss it and avoid duplicated work.
+
+1. I will only review and accept pull requests with tests that cover the changes made.
+
+1. Always create an issue before starting to work on a new feature or bug fix, so we can discuss it and avoid duplicated work.
 
 And **one** wish:
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ docker compose up test
 
 If you want to contribute to this project, you can do so by creating an issue! And if you want to contribute with code, you can fork the repository and create a pull request.
 
-Check the [CONTRIBUTING](CONTRIBUTING) file for more information on how to contribute.
+Check the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on how to contribute.
 
 ## Is it true that bananas are radioactive?
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@
      |__/             |___/
 ```
 
+## What's in here?
+
+- [Who?](#who)
+- [Bu... but why?](#bu-but-why)
+- [How do I use it?](#how-do-i-use-it)
+- [A little piece of documentation](#a-little-piece-of-documentation)
+- [What can I configure?](#what-can-i-configure)
+- [How does it hook into the admin?](#how-does-it-hook-into-the-admin)
+- [Translation support](#translation-support)
+- [What might trip me up?](#what-might-trip-me-up)
+- [Anything else?](#anything-else)
+  - [Running the example app](#running-the-example-app)
+  - [Running the tests](#running-the-tests)
+- [How do I contribute?](#how-do-i-contribute)
+- [Is it true that bananas are radioactive?](#is-it-true-that-bananas-are-radioactive)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ## Who?
 
 **Django Shelf** is meant to be a simple way to categorize your model admins instead of relying on creating new apps for each category.
@@ -72,6 +89,14 @@ Before shelf:
 After shelf:
 ![After using admin shelf](https://raw.githubusercontent.com/niltonfrederico/django-shelf/refs/heads/main/docs/assets/after-shelf.png)
 
+## What can I configure?
+
+<!-- TODO: DJANGO_ADMIN_SHELF table (HIDE_CATEGORIZED_MODELS, CATEGORY_DEFAULT_ORDER, MODEL_DEFAULT_ORDER) + paragraph on categorized vs plain coexistence (_categorize_models flow at conceptual level). -->
+
+## How does it hook into the admin?
+
+<!-- TODO: explain that adding admin_shelf to INSTALLED_APPS swaps admin.site.__class__ via apps.py:ready(); cover the custom AdminSite subclass edge case. -->
+
 ## Translation support
 
 `Category(name=...)` accepts both plain strings and Django's lazy translation
@@ -98,6 +123,10 @@ switching languages see the category label update accordingly.
 across `@register` calls. Buckets are keyed by `name`, so two `Category("Shop")`
 end up merged anyway — but sharing one instance keeps intent obvious and makes
 a later rename a one-liner.
+
+## What might trip me up?
+
+<!-- TODO: reusing same Category instance across files, slug derivation from name, lazy-slug URL changes per language, ordering ties (stable sort, insertion order wins), apps disappearing when HIDE_CATEGORIZED_MODELS=True and all models are categorized. -->
 
 ## Anything else?
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 - [Bu... but why?](#bu-but-why)
 - [How do I use it?](#how-do-i-use-it)
 - [A little piece of documentation](#a-little-piece-of-documentation)
-- [What can I configure?](#what-can-i-configure)
-- [How does it hook into the admin?](#how-does-it-hook-into-the-admin)
-- [Translation support](#translation-support)
-- [What might trip me up?](#what-might-trip-me-up)
+  - [What can I configure?](#what-can-i-configure)
+  - [How does it hook into the admin?](#how-does-it-hook-into-the-admin)
+  - [Translation support](#translation-support)
+  - [What might trip me up?](#what-might-trip-me-up)
 - [Anything else?](#anything-else)
   - [Running the example app](#running-the-example-app)
   - [Running the tests](#running-the-tests)
@@ -89,7 +89,7 @@ Before shelf:
 After shelf:
 ![After using admin shelf](https://raw.githubusercontent.com/niltonfrederico/django-shelf/refs/heads/main/docs/assets/after-shelf.png)
 
-## What can I configure?
+### What can I configure?
 
 Settings live under `DJANGO_ADMIN_SHELF` in your Django settings, as a dict. All keys are optional — the defaults are sane.
 
@@ -111,7 +111,7 @@ Under the hood, when Django builds its admin app list this library walks each ap
 
 If `HIDE_CATEGORIZED_MODELS` is `True` and **every** model in an app ends up categorized, the original app section just disappears from the sidebar — there is nothing left to show.
 
-## How does it hook into the admin?
+### How does it hook into the admin?
 
 You don't need to touch `admin.site` yourself. As soon as `admin_shelf` is in `INSTALLED_APPS`, the app's `ready()` hook mutates `admin.site.__class__` to `CategorizedAdminSite`. The singleton stays the same — only its class changes — so anything you had already wired to `admin.site` keeps working.
 
@@ -124,7 +124,7 @@ class MyAdminSite(CategorizedAdminSite):
     site_header = "My project"
 ```
 
-## Translation support
+### Translation support
 
 `Category(name=...)` accepts both plain strings and Django's lazy translation
 proxies. To localize a category, pass a `gettext_lazy` value:
@@ -151,7 +151,7 @@ across `@register` calls. Buckets are keyed by `name`, so two `Category("Shop")`
 end up merged anyway — but sharing one instance keeps intent obvious and makes
 a later rename a one-liner.
 
-## What might trip me up?
+### What might trip me up?
 
 A few edges worth knowing about:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![codecov](https://codecov.io/github/niltonfrederico/django-shelf/branch/main/graph/badge.svg?token=SATSBNDY0B)](https://codecov.io/github/niltonfrederico/django-shelf)
-![pip](https://img.shields.io/pypi/v/django-admin-shelf
-)
+![pip](https://img.shields.io/pypi/v/django-admin-shelf)
 
 ```
  ░▒▓███████▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░▒▓█▓▒░      ░▒▓████████▓▒░
@@ -13,17 +12,20 @@
 ```
 
 ## Who?
+
 **Django Shelf** is meant to be a simple way to categorize your model admins instead of relying on creating new apps for each category.
 
 ## Bu... but why?
+
 The main reason is simply to avoid creating new apps for each category of model admins. This is especially useful if you got legacy applications that will break if you try to split them into new apps.
 
 Yes, I know that this is not the best practice, but sometimes you just need to do it.
 
 ## How do I use it?
+
 1. Install the package using `pip install django-admin-shelf`.
-2. Add `admin_shelf` to your `INSTALLED_APPS` in your Django settings.
-3. Create categories in your `admin.py` file as follows:
+1. Add `admin_shelf` to your `INSTALLED_APPS` in your Django settings.
+1. Create categories in your `admin.py` file as follows:
 
 ```python
 from admin_shelf.admin import Category
@@ -96,22 +98,27 @@ Python objects and would create separate buckets.
 ### Running the example app
 
 To run the example app, you can use the following commands:
+
 ```bash
 # You need to have docker installed
 docker compose up example
 ```
 
 ### Running the tests
+
 To run the tests, you can use the following commands:
+
 ```bash
 # You need to have docker installed
 docker compose up test
 ```
 
 ## How do I contribute?
+
 If you want to contribute to this project, you can do so by creating an issue! And if you want to contribute with code, you can fork the repository and create a pull request.
 
 Check the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on how to contribute.
 
 ## Is it true that bananas are radioactive?
+
 Yes.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 ![pip](https://img.shields.io/pypi/v/django-admin-shelf)
 
 ```
- ░▒▓███████▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░▒▓█▓▒░      ░▒▓████████▓▒░
-░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░
-░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░
- ░▒▓██████▓▒░░▒▓████████▓▒░▒▓██████▓▒░ ░▒▓█▓▒░      ░▒▓██████▓▒░
-       ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░
-       ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░
-░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░
+  ____  _                           ____  _          _  __
+ |  _ \(_) __ _ _ __   __ _  ___   / ___|| |__   ___| |/ _|
+ | | | | |/ _` | '_ \ / _` |/ _ \  \___ \| '_ \ / _ \ | |_
+ | |_| | | (_| | | | | (_| | (_) |  ___) | | | |  __/ |  _|
+ |____// |\__,_|_| |_|\__, |\___/  |____/|_| |_|\___|_|_|
+     |__/             |___/
 ```
 
 ## Who?
@@ -28,6 +27,8 @@ Yes, I know that this is not the best practice, but sometimes you just need to d
 1. Create categories in your `admin.py` file as follows:
 
 ```python
+from django.contrib import admin
+
 from admin_shelf.admin import Category
 from example.models import Model1
 
@@ -42,11 +43,13 @@ class Model1Admin(admin.ModelAdmin):
 
 The `admin_shelf.admin.Category` class is used to create categories for your model admins. You can register your model admins to these categories using the `@category.register(Model)` decorator.
 
-You can set a order for both the categories and the model admins by passing an `order` argument to the `Category` class and the `@register` decorator, respectively.
+You can set an order for both the categories and the model admins by passing an `order` argument to the `Category` class and the `@register` decorator, respectively.
 
 Example:
 
 ```python
+from django.contrib import admin
+
 from admin_shelf.admin import Category
 from example.models import Model1, Model2
 
@@ -61,7 +64,7 @@ class Model2Admin(admin.ModelAdmin):
     pass
 ```
 
-Yes, it is just that simple. You can also use the `@register` decorator without passing a category, in which case it will be registered to the default category. Or use the default `register` from django admin if you want to register your model admin without a category.
+Yes, it is just that simple. Use the default `register` from django admin if you want to register your model admin without a category.
 
 Before shelf:
 ![Before using admin shelf](https://raw.githubusercontent.com/niltonfrederico/django-shelf/refs/heads/main/docs/assets/before-shelf.png)
@@ -75,8 +78,11 @@ After shelf:
 proxies. To localize a category, pass a `gettext_lazy` value:
 
 ```python
+from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
+
 from admin_shelf.admin import Category
+from myapp.models import Product
 
 shop_category = Category(name=_("Shop"))
 
@@ -89,9 +95,9 @@ The name is resolved against the active language on every request, so users
 switching languages see the category label update accordingly.
 
 **Recommendation:** define each `Category` once and reuse the same instance
-across `@register` calls. Categories are deduplicated by the identity of the
-`name` value; two lazy proxies built from the same source string are distinct
-Python objects and would create separate buckets.
+across `@register` calls. Buckets are keyed by `name`, so two `Category("Shop")`
+end up merged anyway — but sharing one instance keeps intent obvious and makes
+a later rename a one-liner.
 
 ## Anything else?
 
@@ -117,7 +123,7 @@ docker compose up test
 
 If you want to contribute to this project, you can do so by creating an issue! And if you want to contribute with code, you can fork the repository and create a pull request.
 
-Check the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on how to contribute.
+Check the [CONTRIBUTING](CONTRIBUTING) file for more information on how to contribute.
 
 ## Is it true that bananas are radioactive?
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-[![codecov](https://codecov.io/github/niltonfrederico/django-shelf/branch/main/graph/badge.svg?token=SATSBNDY0B)](https://codecov.io/github/niltonfrederico/django-shelf)
-![pip](https://img.shields.io/pypi/v/django-admin-shelf)
-
-```
+<table align="center">
+<tr><td><pre>
   ____  _                           ____  _          _  __
  |  _ \(_) __ _ _ __   __ _  ___   / ___|| |__   ___| |/ _|
  | | | | |/ _` | '_ \ / _` |/ _ \  \___ \| '_ \ / _ \ | |_
  | |_| | | (_| | | | | (_| | (_) |  ___) | | | |  __/ |  _|
  |____// |\__,_|_| |_|\__, |\___/  |____/|_| |_|\___|_|_|
      |__/             |___/
-```
+</pre></td></tr>
+<tr><td align="center">
+<a href="https://codecov.io/github/niltonfrederico/django-shelf"><img src="https://codecov.io/github/niltonfrederico/django-shelf/branch/main/graph/badge.svg?token=SATSBNDY0B" alt="codecov"/></a>
+<img src="https://img.shields.io/pypi/v/django-admin-shelf" alt="pip"/>
+</td></tr>
+</table>
 
 ## What's in here?
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ## What's in here?
 
+- [What's in here?](#whats-in-here)
 - [Who?](#who)
 - [Bu... but why?](#bu-but-why)
 - [How do I use it?](#how-do-i-use-it)
@@ -25,7 +26,6 @@
   - [Running the tests](#running-the-tests)
 - [How do I contribute?](#how-do-i-contribute)
 - [Is it true that bananas are radioactive?](#is-it-true-that-bananas-are-radioactive)
-- [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Who?
 
@@ -91,11 +91,38 @@ After shelf:
 
 ## What can I configure?
 
-<!-- TODO: DJANGO_ADMIN_SHELF table (HIDE_CATEGORIZED_MODELS, CATEGORY_DEFAULT_ORDER, MODEL_DEFAULT_ORDER) + paragraph on categorized vs plain coexistence (_categorize_models flow at conceptual level). -->
+Settings live under `DJANGO_ADMIN_SHELF` in your Django settings, as a dict. All keys are optional — the defaults are sane.
+
+```python
+DJANGO_ADMIN_SHELF = {
+    "HIDE_CATEGORIZED_MODELS": True,
+    "CATEGORY_DEFAULT_ORDER": 0,
+    "MODEL_DEFAULT_ORDER": 0,
+}
+```
+
+| Key                       | Default | What it does                                                                                                                                     |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HIDE_CATEGORIZED_MODELS` | `True`  | When `True`, a categorized model only shows up inside its category. When `False`, it shows up in both the category and its original app section. |
+| `CATEGORY_DEFAULT_ORDER`  | `0`     | Order used when a `Category` is created without an explicit `order`.                                                                             |
+| `MODEL_DEFAULT_ORDER`     | `0`     | Order used when a model is registered without an explicit `order`.                                                                               |
+
+Under the hood, when Django builds its admin app list this library walks each app's models. If a model was registered through `@category.register(...)`, it gets moved (or copied, depending on `HIDE_CATEGORIZED_MODELS`) into a bucket named after the category. Categories are then sorted by `order`, and so are the models inside each category.
+
+If `HIDE_CATEGORIZED_MODELS` is `True` and **every** model in an app ends up categorized, the original app section just disappears from the sidebar — there is nothing left to show.
 
 ## How does it hook into the admin?
 
-<!-- TODO: explain that adding admin_shelf to INSTALLED_APPS swaps admin.site.__class__ via apps.py:ready(); cover the custom AdminSite subclass edge case. -->
+You don't need to touch `admin.site` yourself. As soon as `admin_shelf` is in `INSTALLED_APPS`, the app's `ready()` hook mutates `admin.site.__class__` to `CategorizedAdminSite`. The singleton stays the same — only its class changes — so anything you had already wired to `admin.site` keeps working.
+
+If you maintain your **own** `AdminSite` subclass, that mutation will overwrite it. In that case, inherit from `CategorizedAdminSite` directly:
+
+```python
+from admin_shelf.admin import CategorizedAdminSite
+
+class MyAdminSite(CategorizedAdminSite):
+    site_header = "My project"
+```
 
 ## Translation support
 
@@ -126,7 +153,17 @@ a later rename a one-liner.
 
 ## What might trip me up?
 
-<!-- TODO: reusing same Category instance across files, slug derivation from name, lazy-slug URL changes per language, ordering ties (stable sort, insertion order wins), apps disappearing when HIDE_CATEGORIZED_MODELS=True and all models are categorized. -->
+A few edges worth knowing about:
+
+- **One `Category` per name, please.** Buckets are keyed by `category.name`, so multiple `Category("Shop")` instances merge into the same bucket. It works, but defining each category once and importing it from a single module keeps intent obvious and saves you from chasing duplicates when you want to rename.
+
+- **Category URLs come from the slug of the name.** `Category(name="Custom Category")` lives at `/admin/custom-category/`. The slug is computed from `str(name)` at request time, so it always reflects the current value of the name.
+
+- **Lazy names change URLs per language.** With `Category(name=_("Shop"))`, the URL gets translated too — `/admin/shop/` in English, `/admin/loja/` in Portuguese. Bookmarks and external links pointing at the old slug will 404 after a language switch. If you need a stable URL across languages, use a plain string `name`. ([#27](https://github.com/niltonfrederico/django-shelf/issues/27) tracks a config knob to make this opt-in.)
+
+- **Order ties keep insertion order.** Sorting is stable. Two categories with the same `order` (including the default `0`) appear in the order they were first registered. Non-categorized apps also count as `0`, so they interleave with categorized ones unless you bump categories above `0`. ([#28](https://github.com/niltonfrederico/django-shelf/issues/28) tracks a configurable sub-sort — alphabetical or custom callable — to break ties.)
+
+- **Apps can disappear.** With `HIDE_CATEGORIZED_MODELS=True` (default), if every model in an app gets moved into categories, the original app section vanishes from the sidebar. Intentional — there is nothing left to show — but it can surprise you when a familiar group "disappears" after a refactor.
 
 ## Anything else?
 
@@ -156,4 +193,4 @@ Check the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on how to
 
 ## Is it true that bananas are radioactive?
 
-Yes.
+[Yes](https://www.epa.gov/radtown/natural-radioactivity-food).


### PR DESCRIPTION
Addresses #12.

## Summary
- New TOC under `## What's in here?`, with anchors for every section.
- Three new sub-sections under `## A little piece of documentation`:
  - `### What can I configure?` — `DJANGO_ADMIN_SHELF` settings table and a paragraph on the categorization flow.
  - `### How does it hook into the admin?` — explains the `admin.site.__class__` mutation in `apps.py:ready()` and the custom `AdminSite` edge case.
  - `### What might trip me up?` — five gotchas (category dedup, slug derivation, lazy-name URL shifts, ordering ties, apps disappearing under `HIDE_CATEGORIZED_MODELS=True`).
- Fix broken code samples (missing `from django.contrib import admin` in three blocks, missing `Product` import in the translation example).
- Drop the incorrect "default category" sentence — there is no default category.
- Rewrite the Translation `**Recommendation:**` paragraph; the original claim about lazy-proxy identity was wrong (buckets are keyed by `name` via dict hash/eq, not identity).
- Center the ASCII logo and badges using an `<table align="center">` wrap (only reliable way to center pre-formatted content on GitHub).
- Rename `CONTRIBUTING` → `CONTRIBUTING.md` so it renders as markdown on GitHub and the README link resolves.
- Fix nested list numbering and indent in `CONTRIBUTING.md`.
- Add `mdformat` (with `mdformat-gfm`) as a pre-commit hook, plus `.mdformat.toml` with `wrap = "keep"`, `number = false`, `end_of_line = "lf"`.

## Issue #12 checklist

- [x] `HIDE_CATEGORIZED_MODELS` setting + categorized vs plain coexistence
- [x] `CategorizedAdminSite` requirement (it's automatic — documented why)
- [x] FAQ / Gotchas section
- [x] API reference strategy — keep README-only for now (surface is small)
- [~] `Category(order=...)` semantics — covered in the order example and the ordering-ties gotcha; deeper drill-down deferred
- [~] Translation worked example — kept basic example; expanded mirror of `example/admin.py` deferred

## Follow-ups spawned during the writeup
- #27 — stable category URLs for lazy names
- #28 — configurable sub-sort for ordering ties

## Test plan
- [x] Render the README on GitHub: TOC anchors resolve, centered logo + badges row look right.
- [x] Confirm `CONTRIBUTING.md` renders as markdown on GitHub.
- [x] `pre-commit run --all-files` clean.